### PR TITLE
routing problem solved by Hashrouter & updated homepage url

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jkosc-frontend",
   "version": "0.1.0",
   "private": true,
-  "homepage": "https://jk-open-source-community.github.io/JKOSC/",
+  "homepage": "https://jk-open-source-community.github.io/",
   "dependencies": {
     "@material-ui/core": "^4.11.4",
     "@material-ui/icons": "^4.11.2",

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Navbar from './Components/Navbar/Navbar'
-import { BrowserRouter as Router, Switch, Route } from 'react-router-dom'
+import { BrowserRouter, HashRouter as Router, Switch, Route } from 'react-router-dom'
 import './App.css'
 import HomePage from './pages/homePage/HomePage'
 import CoursePage from './pages/coursePage/CoursePage'


### PR DESCRIPTION

 ### Changes:
 <!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

* 1) Before this, we were getting problem after deploying, on reloading different pages link it was giving routing error as "Error 404 Page Not Found"

![image](https://user-images.githubusercontent.com/53634176/117573008-4f5d7b00-b0f3-11eb-9674-c028c99967d2.png)

Now This Problem is solved by using HashRouter instead of BrowserRouter.

![image](https://user-images.githubusercontent.com/53634176/117573064-96e40700-b0f3-11eb-9d2a-7b797c125fab.png)

* 2) Another change in homepage url, because before this orginal page was loading in "https://jk-open-source-community.github.io/JKOSC/" but we want to open it in "https://jk-open-source-community.github.io/", so i have modified its homepage url in package.json file.
![image](https://user-images.githubusercontent.com/53634176/117573168-27224c00-b0f4-11eb-9fdb-33adc4e28e35.png)




 ### Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
At the current scenario, our page is looking like this-
* Home Page
![image](https://user-images.githubusercontent.com/53634176/117573248-736d8c00-b0f4-11eb-91a9-fb6bee63b5b2.png)

* Incept Page
![image](https://user-images.githubusercontent.com/53634176/117573274-9a2bc280-b0f4-11eb-82eb-bfa04a70dc56.png)




